### PR TITLE
Don't link for dcompute tests

### DIFF
--- a/tests/codegen/dcompute_cl_addrspaces.d
+++ b/tests/codegen/dcompute_cl_addrspaces.d
@@ -1,7 +1,7 @@
 // Test addrspace
 
 // REQUIRES: target_SPIRV
-// RUN: %ldc -mdcompute-targets=ocl-220 -m64 -output-ll -output-o %s && FileCheck %s --check-prefix=LL < kernels_ocl220_64.ll && llvm-spirv -to-text kernels_ocl220_64.spv && FileCheck %s --check-prefix=SPT < kernels_ocl220_64.spt
+// RUN: %ldc -c -mdcompute-targets=ocl-220 -m64 -output-ll -output-o %s && FileCheck %s --check-prefix=LL < kernels_ocl220_64.ll && llvm-spirv -to-text kernels_ocl220_64.spv && FileCheck %s --check-prefix=SPT < kernels_ocl220_64.spt
 @compute(CompileFor.deviceOnly) module dcompute_cl_addrspaces;
 import ldc.attributes;
 import ldc.dcomputetypes;

--- a/tests/codegen/dcompute_cu_addrspaces.d
+++ b/tests/codegen/dcompute_cu_addrspaces.d
@@ -1,7 +1,7 @@
 // Test addrspace
 
 // REQUIRES: target_NVPTX
-// RUN: %ldc -mdcompute-targets=cuda-350 -m64 -output-ll -output-o %s && FileCheck %s --check-prefix=LL < kernels_cuda350_64.ll && FileCheck %s --check-prefix=PTX < kernels_cuda350_64.ptx
+// RUN: %ldc -c -mdcompute-targets=cuda-350 -m64 -output-ll -output-o %s && FileCheck %s --check-prefix=LL < kernels_cuda350_64.ll && FileCheck %s --check-prefix=PTX < kernels_cuda350_64.ptx
 @compute(CompileFor.deviceOnly) module dcompute_cu_addrspaces;
 import ldc.attributes;
 import ldc.dcomputetypes;


### PR DESCRIPTION
they do not output a .o[bj]